### PR TITLE
Change order of entries in state array

### DIFF
--- a/pyenvisalink/alarm_state.py
+++ b/pyenvisalink/alarm_state.py
@@ -8,13 +8,25 @@ class AlarmState:
         _alarmState = {'partition': {}, 'zone': {}}
 
         for i in range(1, maxPartitions + 1):
-            _alarmState['partition'][i] = {'status': {'alarm': False, 'alarm_in_memory': False, 'armed_away': False,
-                                                      'ac_present': True, 'armed_bypass': False, 'chime': False,
-                                                      'armed_zero_entry_delay': False, 'alarm_fire_zone': False,
-                                                      'trouble': False, 'bat_trouble': False, 'ready': False, 'fire': False,
-                                                      'armed_stay': False, 'alpha': 'N/A', 'beep': False,
-                                                      'exit_delay': False, 'entry_delay': False, 'last_disarmed_by_user': '',
-                                                      'last_armed_by_user': '' }}
+            _alarmState['partition'][i] = {'status': {'alpha': 'N/A', 
+                                                      'ac_present': True, 
+                                                      'beep': False, 
+                                                      'chime': False, 
+                                                      'entry_delay': False, 
+                                                      'exit_delay': False, 
+                                                      'last_armed_by_user': '', 
+                                                      'last_disarmed_by_user': '', 
+                                                      'ready': False, 
+                                                      'bat_trouble': False, 
+                                                      'trouble': False, 
+                                                      'fire': False, 
+                                                      'alarm': False, 
+                                                      'alarm_fire_zone': False, 
+                                                      'alarm_in_memory': False, 
+                                                      'armed_away': False, 
+                                                      'armed_bypass': False, 
+                                                      'armed_stay': False, 
+                                                      'armed_zero_entry_delay': False }}
         for j in range (1, maxZones + 1):
             _alarmState['zone'][j] = {'status': {'open': False, 'fault': False, 'alarm': False, 'tamper': False}, 'last_fault': 0}
 

--- a/pyenvisalink/alarm_state.py
+++ b/pyenvisalink/alarm_state.py
@@ -8,9 +8,11 @@ class AlarmState:
         _alarmState = {'partition': {}, 'zone': {}}
 
         for i in range(1, maxPartitions + 1):
-            _alarmState['partition'][i] = {'status': {'alpha': 'N/A', 
+            _alarmState['partition'][i] = {'status': {'partition_state': 'N/A', 
+                                                      'alpha': 'N/A', 
                                                       'ac_present': True, 
                                                       'beep': False, 
+                                                      'bypass': False, 
                                                       'chime': False, 
                                                       'entry_delay': False, 
                                                       'exit_delay': False, 
@@ -24,7 +26,6 @@ class AlarmState:
                                                       'alarm_fire_zone': False, 
                                                       'alarm_in_memory': False, 
                                                       'armed_away': False, 
-                                                      'armed_bypass': False, 
                                                       'armed_stay': False, 
                                                       'armed_zero_entry_delay': False }}
         for j in range (1, maxZones + 1):


### PR DESCRIPTION
This change reorders the state array to make a little more sense, an application that displays the state array in order was previously very difficult to read. This groups entries by system status, trouble status, alarm status, and arming type. When the system is armed or disarmed after the initial state is loaded, the additional entry 'armed' is added to the end of the array, and the grouping is maintained. I kept 'alpha' before 'ac_present' so it did not break up the booleans 1 entry in