### PR TITLE
Implement functionality for last armed/disarmed user on Honeywell 

### DIFF
--- a/pyenvisalink/honeywell_client.py
+++ b/pyenvisalink/honeywell_client.py
@@ -193,13 +193,18 @@ class HoneywellClient(EnvisalinkClient):
         eventType = evl_CID_Qualifiers[eventTypeInt]
         cidEventInt = int(data[1:4])
         cidEvent = evl_CID_Events[cidEventInt]
-        partition = data[4:6]
+        partitionNumber = int(data[4:6])
         zoneOrUser = int(data[6:9])
-
+        if cidEventInt in evl_ArmDisarm_CIDs:
+            if eventTypeInt == 1:
+                self._alarmPanel.alarm_state['partition'][partitionNumber]['status'].update({'last_disarmed_by_user': zoneOrUser})
+            if eventTypeInt == 3:
+                self._alarmPanel.alarm_state['partition'][partitionNumber]['status'].update({'last_armed_by_user': zoneOrUser})
+        
         _LOGGER.debug('Event Type is ' + eventType)
         _LOGGER.debug('CID Type is ' + cidEvent['type'])
         _LOGGER.debug('CID Description is ' + cidEvent['label'])
-        _LOGGER.debug('Partition is ' + partition)
+        _LOGGER.debug('Partition is ' + str(partitionNumber))
         _LOGGER.debug(cidEvent['type'] + ' value is ' + str(zoneOrUser))
         
         return cidEvent

--- a/pyenvisalink/honeywell_envisalinkdefs.py
+++ b/pyenvisalink/honeywell_envisalinkdefs.py
@@ -98,6 +98,8 @@ evl_CID_Qualifiers = {
     6 : 'Previously Reported Condition Still Present'
 }
 
+evl_ArmDisarm_CIDs = [401, 403, 407, 408, 409, 441, 442]
+
 evl_CID_Events = {
     100 : {
     "label" : "Medical Alert",


### PR DESCRIPTION
This will only update after a CID event is received containing the user ID, it will not populate upon connection to the EVL. Reports ID as an integer so calling application can translate to a name from a list. ID of 0 is reported when the panel is quick armed. This commit also converts partition number to a single digit for debug logging.