### PR TITLE
Add tracking of zone bypass status for DSC panels.

### DIFF
--- a/pyenvisalink/alarm_state.py
+++ b/pyenvisalink/alarm_state.py
@@ -29,6 +29,6 @@ class AlarmState:
                                                       'armed_stay': False, 
                                                       'armed_zero_entry_delay': False }}
         for j in range (1, maxZones + 1):
-            _alarmState['zone'][j] = {'status': {'open': False, 'fault': False, 'alarm': False, 'tamper': False}, 'last_fault': 0}
+            _alarmState['zone'][j] = {'status': {'open': False, 'fault': False, 'alarm': False, 'tamper': False}, 'last_fault': 0, 'bypassed': False}
 
         return _alarmState

--- a/pyenvisalink/dsc_envisalinkdefs.py
+++ b/pyenvisalink/dsc_envisalinkdefs.py
@@ -84,7 +84,10 @@ evl_ResponseTypes = {
     '803' : {'name':'ACTroubleOff', 'handler':'keypad_update', 'status':{'ac_present': True, 'alpha' : 'AC Power Restored'}},
     '829' : {'name':'SystemTamper', 'handler':'keypad_update', 'status':{'alpha' : 'System tamper'}},
     '830' : {'name':'SystemTamperOff', 'handler':'keypad_update', 'status':{'alpha' : 'System tamper Restored'}},
-    '849' : {'name':'TroubleVerbose', 'handler':'keypad_update', 'status':None}
+    '849' : {'name':'TroubleVerbose', 'handler':'keypad_update', 'status':None},
+
+#ZONE BYPASS UPDATES
+    '616' : {'name':'Zone Bypass', 'handler':'zone_bypass_update', 'status':None}
 }
 
 evl_verboseTrouble = {


### PR DESCRIPTION
Exposing a DSC panel's zone bypass status such that switches can then be generated in the home-assistant envisalink integration which accurately reflect the bypass status.

I don't have a Honeywell panel but from what I could see in the documentation, there unfortunately isn't a way to query the bypass status anyway so it doesn't look like parity across the two panels is possible.