### PR TITLE
Fix keypad updates with commas in them from failing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ todo
 /*.egg-info
 
 __pycache__
+
+.idea/

--- a/pyenvisalink/honeywell_client.py
+++ b/pyenvisalink/honeywell_client.py
@@ -110,9 +110,13 @@ class HoneywellClient(EnvisalinkClient):
     def handle_keypad_update(self, code, data):
         """Handle the response to when the envisalink sends keypad updates our way."""
         dataList = data.split(',')
-        # make sure data is in format we expect, current TPI seems to send bad data every so ofen
+        # Custom messages and alpha fields might contain unescaped commas, so we'll recombine them:
+        if len(dataList) > 5:
+            dataList[4] = ",".join(dataList[4:])
+            del dataList[5:]
+        # make sure data is in format we expect, current TPI seems to send bad data every so often
         #TODO: Make this a regex...
-        if len(dataList) != 5 or "%" in data:
+        if "%" in data:
             _LOGGER.error("Data format invalid from Envisalink, ignoring...")
             return
 


### PR DESCRIPTION
Hello!

I was excited to find this project, I've been loving having my alarm panel in Homeassistant.  On my Honeywell 20P, I was having some trouble with updates showing up when the panel is disarmed, and tracked the problem down to this part of the code with a packet capture.

In certain cases, the alpha line can contain commas that aren't escaped by the envisalink, so the disarmed status updates on my panel look like this:

```%00,01,1C28,08,00,HOWLIDAY INN :3 CHIME,Rdy to Arm$```

That comma in particular is being added by the panel, but it's also possible for a custom alpha message to be programmed with one or more commas.

Hope this helps :smile: 
