### PR TITLE
Wake DSC panel from keypad blanking before arm/disarm commands

### DIFF
--- a/pyenvisalink/dsc_client.py
+++ b/pyenvisalink/dsc_client.py
@@ -70,16 +70,31 @@ class DSCClient(EnvisalinkClient):
         """Send a keepalive command to reset it's watchdog timer."""
         await self.queue_command(evl_Commands["KeepAlive"], "")
 
+    async def _wake_panel(self, partitionNumber):
+        """Wake DSC panel from keypad blanking state before sending commands.
+
+        DSC panels enter a low-power display-off (blanking) mode after
+        inactivity. TPI arm/disarm commands sent while blanked are rejected
+        with error 024 (system not ready to arm). Sending '#' wakes the
+        panel, equivalent to pressing # on the physical keypad.
+        """
+        _LOGGER.debug("Sending '#' keypress to wake panel from possible blanking state")
+        await self.keypresses_to_partition(partitionNumber, "#")
+        await asyncio.sleep(1)
+
     async def arm_stay_partition(self, code, partitionNumber):
         """Public method to arm/stay a partition."""
+        await self._wake_panel(partitionNumber)
         await self.queue_command(evl_Commands["ArmStay"], str(partitionNumber), code)
 
     async def arm_away_partition(self, code, partitionNumber):
         """Public method to arm/away a partition."""
+        await self._wake_panel(partitionNumber)
         await self.queue_command(evl_Commands["ArmAway"], str(partitionNumber), code)
 
     async def arm_max_partition(self, code, partitionNumber):
         """Public method to arm/max a partition."""
+        await self._wake_panel(partitionNumber)
         await self.queue_command(evl_Commands["ArmMax"], str(partitionNumber), code)
 
     async def arm_night_partition(self, code, partitionNumber, mode=None):
@@ -88,6 +103,7 @@ class DSCClient(EnvisalinkClient):
 
     async def disarm_partition(self, code, partitionNumber):
         """Public method to disarm a partition."""
+        await self._wake_panel(partitionNumber)
         await self.queue_command(evl_Commands["Disarm"], str(partitionNumber) + str(code), code)
 
     async def panic_alarm(self, panicType):


### PR DESCRIPTION
## Summary

DSC panels enter a low-power display-off ("keypad blanking") mode after a period of inactivity. When the panel is in this state, TPI arm/disarm commands (030/031/032/040) are rejected with error 024 ("system not ready to arm") because the EVL pre-validates the panel state and sees it as not ready.

This PR adds a `_wake_panel` method to `DSCClient` that sends a `#` keypress to the partition before each arm/disarm command. This wakes the panel from blanking — equivalent to pressing `#` on the physical keypad. A 1-second delay follows the keypress to allow the panel to broadcast its updated partition state before the actual command is sent.

## Changes

- Added `_wake_panel(partitionNumber)` to `DSCClient` — sends `#` via `keypresses_to_partition` then sleeps 1 second
- Called `_wake_panel` before `arm_stay_partition`, `arm_away_partition`, `arm_max_partition`, and `disarm_partition`
- `arm_night_partition` is unchanged as it delegates to `arm_max_partition`
- `panic_alarm` is unchanged as TPI command 060 bypasses partition validation

## Context

This was originally submitted as a Home Assistant integration-level fix ([home-assistant/core#165286](https://github.com/home-assistant/core/pull/165286)) but reviewers suggested that the fix be added to the underlying library instead.
