### PR TITLE
Buffer TCP reads in data_received to handle frame splits

### DIFF
--- a/pyenvisalink/envisalink_base_client.py
+++ b/pyenvisalink/envisalink_base_client.py
@@ -28,6 +28,7 @@ class EnvisalinkClient(asyncio.Protocol):
         self._shutdown = False
         self._cachedCode = None
         self._reconnect_task = None
+        self._readBuffer = ''
 
     def start(self):
         """Public method for initiating connectivity with the envisalink."""
@@ -102,6 +103,7 @@ class EnvisalinkClient(asyncio.Protocol):
     def disconnect(self):
         """Internal method for forcing connection closure if hung."""
         _LOGGER.debug('Closing connection with server...')
+        self._readBuffer = ''
         if self._transport:
             self._transport.close()
             
@@ -170,19 +172,24 @@ class EnvisalinkClient(asyncio.Protocol):
         
     def data_received(self, data):
         """asyncio callback for any data recieved from the envisalink."""
-        if data != '':
+        if data:
             try:
-                fullData = data.decode('ascii').strip()
-                cmd = {}
+                fullData = data.decode('ascii')
                 result = ''
                 _LOGGER.debug('----------------------------------------')
                 _LOGGER.debug(str.format('RX < {0}', fullData))
-                lines = str.split(fullData, '\r\n')
+                # Buffer reads across chunks: split on CRLF and put the trailing
+                # partial back so frames spanning two recv() calls reassemble.
+                self._readBuffer += fullData
+                lines = self._readBuffer.split('\r\n')
+                self._readBuffer = lines.pop()
             except:
                 _LOGGER.error('Received invalid message. Skipping.')
                 return
 
             for line in lines:
+                if not line:
+                    continue
                 cmd = self.parseHandler(line)
             
                 try:

--- a/pyenvisalink/tests/test_frame_parsing_honeywell.py
+++ b/pyenvisalink/tests/test_frame_parsing_honeywell.py
@@ -1,0 +1,115 @@
+"""Regression tests for data_received buffering across TCP read boundaries.
+
+Without buffering, a frame split across two TCP recv() calls is processed as
+two malformed pieces and logged as "Unrecognized data recieved". These tests
+feed byte chunks through HoneywellClient.data_received and verify each
+complete frame reaches the parser exactly once.
+"""
+
+import unittest
+from unittest.mock import MagicMock
+
+from pyenvisalink import AlarmState
+from pyenvisalink.honeywell_client import HoneywellClient
+
+
+class _TestClient(HoneywellClient):
+    """HoneywellClient with the asyncio side of __init__ skipped, plus a
+    capture of every line that reaches the parser for assertion."""
+
+    def __init__(self):
+        panel = MagicMock()
+        panel.alarm_state = AlarmState.get_initial_alarm_state(64, 8)
+        self._loggedin = True
+        self._alarmPanel = panel
+        self._transport = None
+        self._shutdown = False
+        self._cachedCode = None
+        self._reconnect_task = None
+        self._readBuffer = ''
+        self.parsed = []
+
+    def parseHandler(self, line):
+        self.parsed.append(line)
+        return super().parseHandler(line)
+
+
+class TestDataReceivedBuffering(unittest.TestCase):
+    def setUp(self):
+        self.client = _TestClient()
+
+    def test_complete_frame_in_one_chunk(self):
+        self.client.data_received(b"%01,02000004000000000000000000000000$\r\n")
+        self.assertEqual(self.client.parsed, ["%01,02000004000000000000000000000000$"])
+
+    def test_two_frames_in_one_chunk(self):
+        self.client.data_received(
+            b"%01,02000004000000000000000000000000$\r\n"
+            b"%00,01,1C08,08,00,****DISARMED****  Ready to Arm  $\r\n"
+        )
+        self.assertEqual(self.client.parsed, [
+            "%01,02000004000000000000000000000000$",
+            "%00,01,1C08,08,00,****DISARMED****  Ready to Arm  $",
+        ])
+
+    def test_frame_split_mid_payload(self):
+        """The reproducer for the bug: TCP delivers half a frame, then the rest."""
+        full = b"%00,01,0008,30,00,FAULT 30                        $\r\n"
+        first, second = full[:26], full[26:]
+        self.client.data_received(first)
+        self.assertEqual(self.client.parsed, [])  # truncated line must not reach the parser
+        self.client.data_received(second)
+        self.assertEqual(self.client.parsed, [
+            "%00,01,0008,30,00,FAULT 30                        $",
+        ])
+
+    def test_frame_split_at_terminator(self):
+        """The CRLF itself is split between two recv() calls."""
+        self.client.data_received(b"%02,01000000$\r")
+        self.assertEqual(self.client.parsed, [])
+        self.client.data_received(b"\n")
+        self.assertEqual(self.client.parsed, ["%02,01000000$"])
+
+    def test_split_inside_middle_frame(self):
+        self.client.data_received(
+            b"%01,02000004000000000000000000000000$\r\n"
+            b"%00,01,0008,05,00,FAULT"
+        )
+        self.assertEqual(self.client.parsed, ["%01,02000004000000000000000000000000$"])
+        self.client.data_received(
+            b" 05                        $\r\n"
+            b"%02,03000000$\r\n"
+        )
+        self.assertEqual(self.client.parsed, [
+            "%01,02000004000000000000000000000000$",
+            "%00,01,0008,05,00,FAULT 05                        $",
+            "%02,03000000$",
+        ])
+
+    def test_empty_chunk_is_a_noop(self):
+        self.client.data_received(b"")
+        self.assertEqual(self.client.parsed, [])
+        self.assertEqual(self.client._readBuffer, "")
+
+    def test_login_prompt_is_delivered_when_terminator_arrives(self):
+        """Pre-login the EVL sends 'Login:\\r\\n'; buffer must release it."""
+        self.client._loggedin = False
+        self.client.data_received(b"Login:")
+        self.assertEqual(self.client.parsed, [])
+        self.client.data_received(b"\r\n")
+        self.assertEqual(self.client.parsed, ["Login:"])
+
+    def test_disconnect_clears_partial_buffer(self):
+        """A reconnect must not prepend stale bytes from the previous session."""
+        partial = b"%00,01,0008,30,00,partial-no-CRLF"
+        self.client.data_received(partial)
+        self.assertEqual(self.client._readBuffer, partial.decode())
+        self.client.disconnect()
+        self.assertEqual(self.client._readBuffer, "")
+        # Fresh frame after reconnect parses cleanly without prefix corruption.
+        self.client.data_received(b"%01,02000004000000000000000000000000$\r\n")
+        self.assertEqual(self.client.parsed, ["%01,02000004000000000000000000000000$"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #38.

Following your suggestion to push the v4-line buffering fix here — thanks for
the detailed response on the issue.

## Problem
`asyncio.Protocol.data_received` delivers raw TCP chunks; the current code
treats each chunk as if it were a complete `\r\n`-terminated frame. Frames
split across `recv()` calls are parsed as malformed and logged "Unrecognized
data recieved from the envisalink. Ignoring." See #38 for capture samples.

## Fix
Maintain a per-connection input buffer in `EnvisalinkClient`. Each
`data_received` appends decoded bytes; we split on `\r\n`, hand every
complete line to `parseHandler`, and hold the trailing partial for the next
callback. `disconnect()` clears the buffer so a reconnect doesn't carry
stale bytes. Small adjacent cleanup: tighten `if data != ''` to `if data:`
(the former compares bytes to str under Py3) and filter empty lines in the
loop.

## Diff
- `pyenvisalink/envisalink_base_client.py` — `+11 / −4`, no control-flow
  restructuring
- `pyenvisalink/tests/test_frame_parsing_honeywell.py` — new; 8 cases
  including the canonical mid-payload split, CRLF split,
  three-frames-two-chunks, login-prompt buffering, and
  disconnect-resets-buffer. 6/8 fail without the fix.

## Verification
Running this on my install (HA Core 2026.5.0 / EVL4 / Honeywell Vista)
since 2026-05-10 — pre-patch baseline was 4–7 "Unrecognized" errors/day;
post-patch is **0 errors over ~7 days** with a high volume of `FAULT NN`
keypad updates (the trigger pattern).

This doesn't address the CR/LF-optional and bus-corruption cases you
mentioned — those look more thoroughly handled in `envisalink_new`. This
is intended as just the minimal v4-line fix per your guidance.

Happy to address any review feedback. Thanks for maintaining this library!

---
*Drafted with Claude Code; reviewed, validated against my running install, and submitted by me.*